### PR TITLE
[GITHUB-15] Removes tags

### DIFF
--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -40,7 +40,7 @@
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: false
-        log_driver: none
+        log_driver: "{{ 'none' if ( ansible_version.full | version_compare('2.4',  '>=' )) else 'syslog' }}"
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,8 +24,6 @@ provisioner:
       hash_behaviour: merge
   lint:
     name: ansible-lint
-  options:
-    tags: "assert,build,configure"
 
 # Configures the YAML linter; currently, only support for yamllint is implemented.  Configuration options for
 # yamllint (https://yamllint.readthedocs.io/en/latest/configuration.html) can be specified.


### PR DESCRIPTION
Molecule doesn't seem to create instances when tags are specified,
so this change removes them.

Additionally the syslog none option only works with Ansible 2.4
onwards so a version check has been added.