### PR TITLE
[GITHUB-18] Restrict Travis to develop and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ language: python
 python:
   - 2.7
 
+branches:
+  only:
+    - develop
+    - master
+
 env:
   - ANSIBLE_INSTALL_VERSION=2.2.3.0
   - ANSIBLE_INSTALL_VERSION=2.3.3.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
+        - bionic
 
   # List of tags for your role to enable users to find it easily on Ansible Galaxy.
   # See https://galaxy.ansible.com/explore#/ for inspiration.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,8 @@ platforms:
     image: ubuntu:trusty
   - name: ROLE_NAME-xenial
     image: ubuntu:xenial
+  - name: ROLE_NAME-bionic
+    image: ubuntu:bionic
 
 # Ansible is the only supported provisioner.  Configure Ansible options here, change the linter for Ansible playbooks,
 # or modify the playbooks run for the various molecule tasks.


### PR DESCRIPTION
This stops Travis from running on release tags.

Also added Bionic to test OS list.